### PR TITLE
use squares==1.0.1

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -28,7 +28,7 @@ loguru==0.5.3
 broadcaster[postgres]==0.2.0
 phonenumbers==8.12.27
 nameparser==1.0.6
-squares==1.0.0
+squares==1.0.1
 
 
 # sub dependencies speciefied for dependabot


### PR DESCRIPTION
This removes the `requests` dep which I previously had for getting the tags for PyPI releases.